### PR TITLE
Update ex_15_clt_onerosa.py

### DIFF
--- a/secao_01_estrutura_sequencial/ex_15_clt_onerosa.py
+++ b/secao_01_estrutura_sequencial/ex_15_clt_onerosa.py
@@ -32,9 +32,9 @@ def calcular_assalto_no_salario():
     horas_trabalhadas_no_mes = float(input(''))
 
     salario_bruto = ganhos_por_hora * horas_trabalhadas_no_mes
-    imposto_de_renda = salario_bruto * (11/100)
-    inss = salario_bruto * (8/100)
-    sindicato = salario_bruto * (5/100)
+    imposto_de_renda = salario_bruto * 0.11
+    inss = salario_bruto * 0.08
+    sindicato = salario_bruto * 0.05
     salario_liquido = salario_bruto - imposto_de_renda - inss - sindicato
 
 


### PR DESCRIPTION
Boaaa! Não existe nada de errado aqui está tudo ótimo! Uma sugestão é, ao trabalhar com porcentos, prefira sempre trabalhar com números inteiros. Então 11% significa 0.11, assim como 8 é 0.08 e 5 com 0.05. Porque existe menos riscos de que uma divisão como essa possa interferir no seu código.  Isso vai ajudar também quando for soma com porcento. Por exemplo, somar a = 100 +10%, use a = 100 * 1,10. Isso substitui a necessidade de fazer  a = 100 * 0.10 = 10, depois 100 + 10